### PR TITLE
Permission deletion

### DIFF
--- a/olp/models.py
+++ b/olp/models.py
@@ -1,8 +1,12 @@
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
 from django.db import models
 from django.db.models.query import QuerySet
+
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 
 class ObjectPermissionManager(models.Manager):
@@ -28,7 +32,7 @@ class ObjectPermissionQuerySet(QuerySet):
 
     def for_base_id(self, id):
         return self.filter(base_object_id=id)
-    
+
     def for_base_ids(self, ids):
         return self.filter(base_object_id__in=ids)
 
@@ -50,12 +54,12 @@ class ObjectPermission(models.Model):
     base_object_ct = models.ForeignKey(ContentType, related_name="+")
     base_object_id = models.PositiveIntegerField()
 
-    base_object = generic.GenericForeignKey("base_object_ct", "base_object_id")
+    base_object = GenericForeignKey("base_object_ct", "base_object_id")
 
     target_object_ct = models.ForeignKey(ContentType, related_name="+")
     target_object_id = models.PositiveIntegerField()
 
-    target_object = generic.GenericForeignKey("target_object_ct", "target_object_id")
+    target_object = GenericForeignKey("target_object_ct", "target_object_id")
 
     permission = models.ForeignKey(Permission)
 

--- a/olp/utils.py
+++ b/olp/utils.py
@@ -82,9 +82,9 @@ def remove_perm(user, permission, obj=None):
     return True
 
 
-def remove_permission_for_object(model_instance):
+def remove_all_permissions(model_instance):
     """
-    Removes a permission for a given object.
+    Removes all permissions for a given object.
     """
 
     from django.contrib.contenttypes.models import ContentType

--- a/runtests.py
+++ b/runtests.py
@@ -40,10 +40,12 @@ if args.coverage:
 else:
     cov = None
 
+import django
 from django.conf import settings
 from tests import settings as test_settings
 
 settings.configure(test_settings, debug=True)
+django.setup()
 
 from django.test.utils import get_runner
 

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,5 +1,6 @@
 from olp.utils import patch_models
 from .backend import TestBackendBasic
-from .utils import TestAssignPerm, TestHasPerm, TestRemovePerm, TestRemovePermNotSet, TestGetObjsForUser
+from .utils import TestAssignPerm, TestHasPerm, TestRemovePerm, \
+    TestRemoveAllPermissions, TestRemovePermNotSet, TestGetObjsForUser
 
 patch_models()

--- a/tests/tests/utils.py
+++ b/tests/tests/utils.py
@@ -127,6 +127,7 @@ class TestRemovePerm(TestCase):
         self.assertEqual(result, True)
         self.assertEqual(ObjectPermission.objects.count(), 0)
 
+
 class TestRemovePermNotSet(TestCase):
 
     def setUp(self):
@@ -180,6 +181,50 @@ class TestRemovePermNotSet(TestCase):
             result = self.user.remove_perm(permission, apple)
 
         self.assertEqual(result, True)
+
+
+class TestRemoveAllPermissions(TestCase):
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+
+        self.user = User.objects.create_user("test", "test@test.com", "test")
+        self.user.save()
+
+    def test_remove_permission(self):
+        from olp.utils import remove_all_permissions
+        apple = Apple(name="test")
+        apple.save()
+
+        self.user.assign_perm("tests.can_be_awesome", apple)
+
+        remove_all_permissions(self.user)
+
+        self.assertEqual(ObjectPermission.objects.count(), 0)
+
+    def test_permission_removed_only_from_specified_object(self):
+        from olp.utils import remove_all_permissions
+        from django.contrib.auth.models import User
+
+        self.other_user = User.objects.create_user(
+            "other_test",
+            "other_test@test.com",
+            "other_test"
+        )
+        self.other_user.save()
+
+        apple = Apple(name="test")
+        apple.save()
+
+        self.user.assign_perm("tests.can_be_awesome", apple)
+        self.other_user.assign_perm("tests.can_be_awesome", apple)
+
+        remove_all_permissions(self.user)
+
+        self.assertEqual(ObjectPermission.objects.count(), 1)
+        self.assertFalse(self.user.has_perm("tests.can_be_awesome", apple))
+        self.assertTrue(self.other_user.has_perm("tests.can_be_awesome", apple))
+
 
 class TestGetObjsForUser(TestCase):
     def setUp(self):

--- a/tests/tests/utils.py
+++ b/tests/tests/utils.py
@@ -10,6 +10,8 @@ class TestAssignPerm(TestCase):
     def setUp(self):
         from django.contrib.auth.models import User
 
+        super(TestAssignPerm, self).setUp()
+
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()
 
@@ -68,6 +70,8 @@ class TestHasPerm(TestCase):
     def setUp(self):
         from django.contrib.auth.models import User
 
+        super(TestHasPerm, self).setUp()
+
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()
 
@@ -83,6 +87,8 @@ class TestRemovePerm(TestCase):
 
     def setUp(self):
         from django.contrib.auth.models import User
+
+        super(TestRemovePerm, self).setUp()
 
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()
@@ -132,6 +138,8 @@ class TestRemovePermNotSet(TestCase):
 
     def setUp(self):
         from django.contrib.auth.models import User
+
+        super(TestRemovePermNotSet, self).setUp()
 
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()
@@ -188,6 +196,8 @@ class TestRemoveAllPermissions(TestCase):
     def setUp(self):
         from django.contrib.auth.models import User
 
+        super(TestRemoveAllPermissions, self).setUp()
+
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()
 
@@ -227,8 +237,11 @@ class TestRemoveAllPermissions(TestCase):
 
 
 class TestGetObjsForUser(TestCase):
+
     def setUp(self):
         from django.contrib.auth.models import User
+
+        super(TestGetObjsForUser, self).setUp()
 
         self.user = User.objects.create_user("test", "test@test.com", "test")
         self.user.save()


### PR DESCRIPTION
This adds a utility method to remove existing permissions from a model object. This is commonly useful when deleting objects to make sure that permissions referencing deleted objects do not remain.